### PR TITLE
Add check debug token ins start_param for launch debugging mode

### DIFF
--- a/Client/src/app/App.tsx
+++ b/Client/src/app/App.tsx
@@ -34,7 +34,9 @@ const App = (): JSX.Element => {
   
   setHeaderColor('rgb(14, 14, 14)');
 
-  const debugMode: boolean = webApp.initDataUnsafe.start_param === 'debug';
+  const [ debug, debugToken ] = webApp.initDataUnsafe.start_param.split('_')
+  // @ts-ignore
+  const debugMode = debug === 'debug' && debugToken == import.meta.env.VITE_DEBUG_PASSWORD;
   if (debugMode) {
     import('eruda').then(eruda => eruda.default.init());
   }


### PR DESCRIPTION
For launch application in debugging mode `start_param` mast be like `debug_debugTokenHere`.
```
const [ debug, debugToken ] = webApp.initDataUnsafe.start_param.split('_');
const debugMode = debug === 'debug' && debugToken == import.meta.env.VITE_DEBUG_PASSWORD;
```
`debugToken` must be writted in `./.env ` like `VITE_DEBUG_PASSWORD=XXXXXXXXXXXXXXXX`
* **Issue**: #12 
