### PR TITLE
fix start_param check

### DIFF
--- a/Server/src/user/user.service.ts
+++ b/Server/src/user/user.service.ts
@@ -31,13 +31,18 @@ export class UserService {
             await this.prisma.users_app_data.create({ data: appData })
 
             if (start_param != undefined) {
-                await this.prisma.users_app_data.update({
-                    where: { user_id: start_param },
-                    data: {
-                        balance: { increment: 100 },
-                        friends: { increment: 1 }
-                    }
-                })
+                try {
+                    const check = Number(start_param)
+                    await this.prisma.users_app_data.update({
+                        where: { user_id: start_param },
+                        data: {
+                            balance: { increment: 100 },
+                            friends: { increment: 1 }
+                        }
+                    })
+                } catch (error) {
+                    //
+                }
             }
         }
         


### PR DESCRIPTION
Added an additional `start_param` check when creating a user in the database.
```
if (start_param != undefined) {
    try {
        const check = Number(start_param)
        await this.prisma.users_app_data.update({
            where: { user_id: start_param },
            data: {
                balance: { increment: 100 },
                friends: { increment: 1 }
            }
        })
    } catch (error) {
        //
    }
}
```
* **Issue**: #22 